### PR TITLE
updated for subdomains, updated errors, added overview with links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,17 +13,17 @@ In the first 2 steps, we will be navigating around on your local machine.  If yo
 
 ## Overview of Steps
 * **[Step 0](http://github.com/alex-wap/DjangoDeployment#step-0-replace-your-managepy-file-do-not-forget-to-replace-projectname-and-port-with-your-project-name-and-port-number):** Replace your manage.py file to set PORT
-* **Step 1:** Save your installed pip modules in a text file
-* **Step 2:** Push your project to a GitHub repo
-* **Step 3:** Create an EC2 server instance
-* **Step 4:** Connect to your remote server
-* **Step 5:** Configure your EC2 Server Application
-* **Step 6:** Collect Static Files
-* **Step 7:** Gunicorn (Ubuntu 16.04)
-* **Step 7a:** Gunicorn (Ubuntu 14.04)
-* **Step 8:** Nginx
-* **Step 9:** Nginx Troubleshooting
-* **Step 10:** Add a MySQL server (optional)
+* **[Step 1](http://github.com/alex-wap/DjangoDeployment#step-1-getting-started):** Save your installed pip modules in a text file
+* **[Step 2](http://github.com/alex-wap/DjangoDeployment#step-2-committing):** Push your project to a GitHub repo
+* **[Step 3](http://github.com/alex-wap/DjangoDeployment#step-3-creating-an-ec2-server-instance):** Create an EC2 server instance
+* **[Step 4](http://github.com/alex-wap/DjangoDeployment#step-4-connecting-to-your-remote-server):** Connect to your remote server
+* **[Step 5](http://github.com/alex-wap/DjangoDeployment#step-5-ec2-server-application-configuration):** Configure your EC2 Server Application
+* **[Step 6](http://github.com/alex-wap/DjangoDeployment#step-6-collect-static-files):** Collect Static Files
+* **[Step 7](http://github.com/alex-wap/DjangoDeployment#step-7-gunicorn-ubuntu-1604):** Gunicorn (Ubuntu 16.04)
+* **[Step 7a](http://github.com/alex-wap/DjangoDeployment#step-7a-gunicorn-ubuntu-1404):** Gunicorn (Ubuntu 14.04)
+* **[Step 8](http://github.com/alex-wap/DjangoDeployment#step-8-nginx):** Nginx
+* **[Step 9](http://github.com/alex-wap/DjangoDeployment#step-9---finally):** Nginx Troubleshooting
+* **[Step 10](http://github.com/alex-wap/DjangoDeployment#step-10-adding-a-mysql-server-optional):** Add a MySQL server (optional)
 
 ## Step 0: Replace your manage.py file (do not forget to replace PROJECTNAME and PORT with your project name and port number):
 

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,31 @@ We're going to use github to create a copy of our project in deployment.
 
 In the first 2 steps, we will be navigating around on your local machine.  If you are using unix(mac), or linux, these commands are for you.  If you are on Windows, you will want to use git bash in order for these commands to run properly.
 
+
+## Step 0: Replace your manage.py file (do not forget to replace PROJECTNAME and 8005 with your project name and port number):
+
+```python
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "PROJECTNAME.settings")
+    
+    # Different port manage.py file 
+    import django
+    django.setup()
+
+    # Override default port for `runserver` command
+    from django.core.management.commands.runserver import Command as runserver
+    runserver.default_port = "8005"
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)
+```
+
+
 ## Step 1: Getting Started
 
 Get started by activating your virtual environment.

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ We're going to use github to create a copy of our project in deployment.
 In the first 2 steps, we will be navigating around on your local machine.  If you are using unix(mac), or linux, these commands are for you.  If you are on Windows, you will want to use git bash in order for these commands to run properly.
 
 ## Overview of Steps
-* **Step 0:** Replace your manage.py file to set PORT
+* **[Step 0](https://github.com/alex-wap/DjangoDeployment#step-0-replace-your-managepy-file-do-not-forget-to-replace-projectname-and-port-with-your-project-name-and-port-number):** Replace your manage.py file to set PORT
 * **Step 1:** Save your installed pip modules in a text file
 * **Step 2:** Push your project to a GitHub repo
 * **Step 3:** Create an EC2 server instance

--- a/readme.md
+++ b/readme.md
@@ -260,7 +260,7 @@ Run `cd ..` to get back to the folder that holds `manage.py`. Make sure your vir
 ## Step 7: Gunicorn
 
 
-**WARNING: If you're running Ubuntu 14.04, follow the commands listed in *Note 2 at the end of Step 7*. If you're running Ubuntu 16.04, continue following instructions. **
+**WARNING: If you're running Ubuntu 14.04, follow the commands listed in _Note 2 at the end of Step 7_. If you're running Ubuntu 16.04, continue following instructions. **
 
 
 You may remember that Gunicorn is our process manager. Let's test Gunicorn by directing it to our Django project's wsgi.py file, which is the entry point to our application.
@@ -334,7 +334,7 @@ ubuntu@54.162.31.253:~$ sudo systemctl enable gunicorn
 
 *Note:* if any additional changes are made to the gunicorn.service the previous three commands will need to be run in order to sync things up and restart our service.
 
-**Note 2: If you're running *Ubuntu 14.04, systemctl is not available. Follow the commands listed below. Otherwise, skip to *Step 8*.**
+**Note 2: If you're running _Ubuntu 14.04_, systemctl is not available. Follow the commands listed below. Otherwise, skip to _Step 8_.**
 
 Enter this command:
 

--- a/readme.md
+++ b/readme.md
@@ -523,13 +523,13 @@ server {
         proxy_pass http://unix:/home/ubuntu/REPONAME/PROJECTNAME.sock;
     }
 }
-* Restart gunicorn (Ubuntu 16.04): 
+* Restart gunicorn **(Ubuntu 16.04)**: 
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl start gunicorn
 sudo systemctl enable gunicorn
 ```
-* Restart gunicorn (Ubuntu 14.04): `sudo service gunicorn restart`
+* Restart gunicorn **(Ubuntu 14.04)**: `sudo service gunicorn restart`
 * Restart nginx: `sudo service nginx restart`
 
 

--- a/readme.md
+++ b/readme.md
@@ -473,7 +473,7 @@ If your server restarted correctly, you will see *[OK]* on the right hand side o
 
 ### Bad Gateway 502:
 * Most of time, it's a problem with your file paths. Follow the instructions below:
-* Check your gunicorn.service file first (Ubuntu 16.04):
+* Check your gunicorn.service file first **(Ubuntu 16.04)**:
 * `sudo vim /etc/systemd/system/gunicorn.service`
 * Check REPONAME, PROJECTNAME, and the location of your venv directory:
 ```bash
@@ -490,7 +490,7 @@ ExecStart=/home/ubuntu/REPONAME/venv/bin/gunicorn --workers 3 --bind unix:/home/
 [Install]
 WantedBy=multi-user.target
 ```
-* Check your gunicorn.conf file first (Ubuntu 14.04):
+* Check your gunicorn.conf file first **(Ubuntu 14.04)**:
 * ```sudo vim /etc/init/gunicorn.conf```
 * Check PROJECTNAME, REPONAME, and the location of your venv directory:
 ```bash
@@ -523,6 +523,7 @@ server {
         proxy_pass http://unix:/home/ubuntu/REPONAME/PROJECTNAME.sock;
     }
 }
+```
 * Restart gunicorn **(Ubuntu 16.04)**: 
 ```bash
 sudo systemctl daemon-reload

--- a/readme.md
+++ b/readme.md
@@ -23,8 +23,8 @@ In the first 2 steps, we will be navigating around on your local machine.  If yo
 * **[Step 7a](https://github.com/alex-wap/DjangoDeployment#step-7a-gunicorn-ubuntu-1404):** Gunicorn (Ubuntu 14.04)
 * **[Step 8](https://github.com/alex-wap/DjangoDeployment#step-8-nginx):** Nginx
 * **[Step 9](https://github.com/alex-wap/DjangoDeployment#step-9---finally):** Nginx Troubleshooting
-  * [Internal Server Error 500](https://github.com/alex-wap/DjangoDeployment#internal-server-error-500:)
-  * [Bad Gateway 502](https://github.com/alex-wap/DjangoDeployment#bad-gateway-502:)
+  * [Internal Server Error 500](https://github.com/alex-wap/DjangoDeployment#internal-server-error-500)
+  * [Bad Gateway 502](https://github.com/alex-wap/DjangoDeployment#bad-gateway-502)
 * **[Step 10](https://github.com/alex-wap/DjangoDeployment#step-10-adding-a-mysql-server-optional):** Add a MySQL server (optional)
 
 

--- a/readme.md
+++ b/readme.md
@@ -12,18 +12,18 @@ We're going to use github to create a copy of our project in deployment.
 In the first 2 steps, we will be navigating around on your local machine.  If you are using unix(mac), or linux, these commands are for you.  If you are on Windows, you will want to use git bash in order for these commands to run properly.
 
 ## Overview of Steps
-* **[Step 0](http://github.com/alex-wap/DjangoDeployment#step-0-replace-your-managepy-file-do-not-forget-to-replace-projectname-and-port-with-your-project-name-and-port-number):** Replace your manage.py file to set PORT
-* **[Step 1](http://github.com/alex-wap/DjangoDeployment#step-1-getting-started):** Save your installed pip modules in a text file
-* **[Step 2](http://github.com/alex-wap/DjangoDeployment#step-2-committing):** Push your project to a GitHub repo
-* **[Step 3](http://github.com/alex-wap/DjangoDeployment#step-3-creating-an-ec2-server-instance):** Create an EC2 server instance
-* **[Step 4](http://github.com/alex-wap/DjangoDeployment#step-4-connecting-to-your-remote-server):** Connect to your remote server
+* **[Step 0](https://github.com/alex-wap/DjangoDeployment#step-0-replace-your-managepy-file-do-not-forget-to-replace-projectname-and-port-with-your-project-name-and-port-number):** Replace your manage.py file to set PORT
+* **[Step 1](https://github.com/alex-wap/DjangoDeployment#step-1-getting-started):** Save your installed pip modules in a text file
+* **[Step 2](https://github.com/alex-wap/DjangoDeployment#step-2-committing):** Push your project to a GitHub repo
+* **[Step 3](https://github.com/alex-wap/DjangoDeployment#step-3-creating-an-ec2-server-instance):** Create an EC2 server instance
+* **[Step 4](https://github.com/alex-wap/DjangoDeployment#step-4-connecting-to-your-remote-server):** Connect to your remote server
 * **[Step 5](http://github.com/alex-wap/DjangoDeployment#step-5-ec2-server-application-configuration):** Configure your EC2 Server Application
-* **[Step 6](http://github.com/alex-wap/DjangoDeployment#step-6-collect-static-files):** Collect Static Files
-* **[Step 7](http://github.com/alex-wap/DjangoDeployment#step-7-gunicorn-ubuntu-1604):** Gunicorn (Ubuntu 16.04)
+* **[Step 6](https://github.com/alex-wap/DjangoDeployment#step-6-collect-static-files):** Collect Static Files
+* **[Step 7](https://github.com/alex-wap/DjangoDeployment#step-7-gunicorn-ubuntu-1604):** Gunicorn (Ubuntu 16.04)
 * **[Step 7a](https://github.com/alex-wap/DjangoDeployment#step-7a-gunicorn-ubuntu-1404):** Gunicorn (Ubuntu 14.04)
-* **[Step 8](http://github.com/alex-wap/DjangoDeployment#step-8-nginx):** Nginx
-* **[Step 9](http://github.com/alex-wap/DjangoDeployment#step-9---finally):** Nginx Troubleshooting
-* **[Step 10](http://github.com/alex-wap/DjangoDeployment#step-10-adding-a-mysql-server-optional):** Add a MySQL server (optional)
+* **[Step 8](https://github.com/alex-wap/DjangoDeployment#step-8-nginx):** Nginx
+* **[Step 9](https://github.com/alex-wap/DjangoDeployment#step-9---finally):** Nginx Troubleshooting
+* **[Step 10](https://github.com/alex-wap/DjangoDeployment#step-10-adding-a-mysql-server-optional):** Add a MySQL server (optional)
 
 ## Step 0: Replace your manage.py file (do not forget to replace PROJECTNAME and PORT with your project name and port number):
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ We're going to use github to create a copy of our project in deployment.
 In the first 2 steps, we will be navigating around on your local machine.  If you are using unix(mac), or linux, these commands are for you.  If you are on Windows, you will want to use git bash in order for these commands to run properly.
 
 
-## Step 0: Replace your manage.py file (do not forget to replace PROJECTNAME and 8005 with your project name and port number):
+## Step 0: Replace your manage.py file (do not forget to replace PROJECTNAME and PORT with your project name and port number):
 
 ```python
 #!/usr/bin/env python
@@ -28,7 +28,7 @@ if __name__ == "__main__":
 
     # Override default port for `runserver` command
     from django.core.management.commands.runserver import Command as runserver
-    runserver.default_port = "8005"
+    runserver.default_port = "PORT"
 
     from django.core.management import execute_from_command_line
 

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,19 @@ We're going to use github to create a copy of our project in deployment.
 
 In the first 2 steps, we will be navigating around on your local machine.  If you are using unix(mac), or linux, these commands are for you.  If you are on Windows, you will want to use git bash in order for these commands to run properly.
 
+## Overview of Steps
+* **[Step 0](#step-0):** Replace your manage.py file to set PORT
+* **Step 1:** Save your installed pip modules in a text file
+* **Step 2:** Push your project to a GitHub repo
+* **Step 3:** Create an EC2 server instance
+* **Step 4:** Connect to your remote server
+* **Step 5:** 
+* **Step 6:** 
+* **Step 7:** 
+* **Step 7a:** 
+* **Step 8:** 
+* **Step 9:** 
+* **Step 10:** 
 
 ## Step 0: Replace your manage.py file (do not forget to replace PROJECTNAME and PORT with your project name and port number):
 

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ In the first 2 steps, we will be navigating around on your local machine.  If yo
 * **[Step 5](http://github.com/alex-wap/DjangoDeployment#step-5-ec2-server-application-configuration):** Configure your EC2 Server Application
 * **[Step 6](http://github.com/alex-wap/DjangoDeployment#step-6-collect-static-files):** Collect Static Files
 * **[Step 7](http://github.com/alex-wap/DjangoDeployment#step-7-gunicorn-ubuntu-1604):** Gunicorn (Ubuntu 16.04)
-* **[Step 7a](http://github.com/alex-wap/DjangoDeployment#step-7a-gunicorn-ubuntu-1404):** Gunicorn (Ubuntu 14.04)
+* **[Step 7a](https://github.com/alex-wap/DjangoDeployment#step-7a-gunicorn-ubuntu-1404):** Gunicorn (Ubuntu 14.04)
 * **[Step 8](http://github.com/alex-wap/DjangoDeployment#step-8-nginx):** Nginx
 * **[Step 9](http://github.com/alex-wap/DjangoDeployment#step-9---finally):** Nginx Troubleshooting
 * **[Step 10](http://github.com/alex-wap/DjangoDeployment#step-10-adding-a-mysql-server-optional):** Add a MySQL server (optional)

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ In the first 2 steps, we will be navigating around on your local machine.  If yo
 * **[Step 7](https://github.com/alex-wap/DjangoDeployment#step-7-gunicorn-ubuntu-1604):** Gunicorn (Ubuntu 16.04)
 * **[Step 7a](https://github.com/alex-wap/DjangoDeployment#step-7a-gunicorn-ubuntu-1404):** Gunicorn (Ubuntu 14.04)
 * **[Step 8](https://github.com/alex-wap/DjangoDeployment#step-8-nginx):** Nginx
-* **[Step 9](https://github.com/alex-wap/DjangoDeployment#step-9---finally):** Nginx Troubleshooting
+* **[Step 9](https://github.com/alex-wap/DjangoDeployment#step-9---finally):** Final Steps
   * [Internal Server Error 500](https://github.com/alex-wap/DjangoDeployment#internal-server-error-500)
   * [Bad Gateway 502](https://github.com/alex-wap/DjangoDeployment#bad-gateway-502)
 * **[Step 10](https://github.com/alex-wap/DjangoDeployment#step-10-adding-a-mysql-server-optional):** Add a MySQL server (optional)

--- a/readme.md
+++ b/readme.md
@@ -12,18 +12,18 @@ We're going to use github to create a copy of our project in deployment.
 In the first 2 steps, we will be navigating around on your local machine.  If you are using unix(mac), or linux, these commands are for you.  If you are on Windows, you will want to use git bash in order for these commands to run properly.
 
 ## Overview of Steps
-* **[Step 0](https://github.com/alex-wap/DjangoDeployment#step-0-replace-your-managepy-file-do-not-forget-to-replace-projectname-and-port-with-your-project-name-and-port-number):** Replace your manage.py file to set PORT
+* **Step 0:** Replace your manage.py file to set PORT
 * **Step 1:** Save your installed pip modules in a text file
 * **Step 2:** Push your project to a GitHub repo
 * **Step 3:** Create an EC2 server instance
 * **Step 4:** Connect to your remote server
-* **Step 5:** 
-* **Step 6:** 
-* **Step 7:** 
-* **Step 7a:** 
-* **Step 8:** 
-* **Step 9:** 
-* **Step 10:** 
+* **Step 5:** Configure your EC2 Server Application
+* **Step 6:** Collect Static Files
+* **Step 7:** Gunicorn (Ubuntu 16.04)
+* **Step 7a:** Gunicorn (Ubuntu 14.04)
+* **Step 8:** Nginx
+* **Step 9:** Nginx Troubleshooting
+* **Step 10:** Add a MySQL server (optional)
 
 ## Step 0: Replace your manage.py file (do not forget to replace PROJECTNAME and PORT with your project name and port number):
 

--- a/readme.md
+++ b/readme.md
@@ -330,11 +330,18 @@ ubuntu@54.162.31.253:~$ sudo systemctl enable gunicorn
 
 *Note:* if any additional changes are made to the gunicorn.service the previous three commands will need to be run in order to sync things up and restart our service.
 
-*Note 2:* If you're running Ubuntu 14.04, systemctl is not available. Follow the commands listed below. Otherwise, move on.
+**Note 2: If you're running Ubuntu 14.04, systemctl is not available. Follow the commands listed below. Otherwise, move on.**
 
 Enter this command:
+
+
+
 ```sudo nano /etc/init/gunicorn.conf```
+
+
 Paste in gunicorn.conf: 
+
+
 ```bash
 description "Gunicorn application server handling PROJECT"
 

--- a/readme.md
+++ b/readme.md
@@ -465,10 +465,12 @@ If your server restarted correctly, you will see *[OK]* on the right hand side o
 * cd into your repo: `cd ~/REPONAME`
 * Remove sqllite file: `rm db.sqlite3`
 * Remove migrations folder: `rm -rf apps/APPNAME/migrations`
+* Activate your venv: `source venv/bin/activate`
 * `python manage.py makemigrations APPNAME`
 * `python manage.py migrate`
 * `python manage.py runserver`
 * Control+C if there is no problem.
+* Deactivate your venv: `deactivate`
 * Restart gunicorn **(Ubuntu 16.04)**: `sudo systemctl daemon-reload;sudo systemctl start gunicorn;sudo systemctl enable gunicorn`
 * Restart gunicorn **(Ubuntu 14.04)**: `sudo service gunicorn restart`
 * Restart nginx: `sudo service nginx restart`

--- a/readme.md
+++ b/readme.md
@@ -462,20 +462,22 @@ If your server restarted correctly, you will see *[OK]* on the right hand side o
 
 ### Internal Server Error 500:
 * Most of the time, it's a database error. Follow the instructions below:
-1. Remove sqllite file: `rm db.sqlite3`
-2. Remove migrations folder: `rm -rf apps/APPNAME/migrations`
-3. `python manage.py makemigrations APPNAME`
-4. `python manage.py migrate`
-5. `python manage.py runserver`
-6. Control+C if there is no problem.
-7.
-8.
+* cd into your repo: `cd ~/REPONAME`
+* Remove sqllite file: `rm db.sqlite3`
+* Remove migrations folder: `rm -rf apps/APPNAME/migrations`
+* `python manage.py makemigrations APPNAME`
+* `python manage.py migrate`
+* `python manage.py runserver`
+* Control+C if there is no problem.
+* Restart gunicorn **(Ubuntu 16.04)**: `sudo systemctl daemon-reload;sudo systemctl start gunicorn;sudo systemctl enable gunicorn`
+* Restart gunicorn **(Ubuntu 14.04)**: `sudo service gunicorn restart`
+* Restart nginx: `sudo service nginx restart`
 
 ### Bad Gateway 502:
 * Most of time, it's a problem with your file paths. Follow the instructions below:
 * Check your gunicorn.service file first **(Ubuntu 16.04)**:
-* `sudo vim /etc/systemd/system/gunicorn.service`
-* Check REPONAME, PROJECTNAME, and the location of your venv directory:
+  * `sudo vim /etc/systemd/system/gunicorn.service`
+  * Check REPONAME, PROJECTNAME, and the location of your venv directory:
 ```bash
 [Unit]
 Description=gunicorn daemon
@@ -491,8 +493,8 @@ ExecStart=/home/ubuntu/REPONAME/venv/bin/gunicorn --workers 3 --bind unix:/home/
 WantedBy=multi-user.target
 ```
 * Check your gunicorn.conf file first **(Ubuntu 14.04)**:
-* ```sudo vim /etc/init/gunicorn.conf```
-* Check PROJECTNAME, REPONAME, and the location of your venv directory:
+  * ```sudo vim /etc/init/gunicorn.conf```
+  * Check PROJECTNAME, REPONAME, and the location of your venv directory:
 ```bash
 description "Gunicorn application server handling PROJECTNAME"
 
@@ -506,10 +508,9 @@ chdir /home/ubuntu/REPONAME
 
 exec venv/bin/gunicorn --workers 3 --bind unix:/home/ubuntu/REPONAME/PROJECTNAME.sock PROJECTNAME.wsgi:application
 ```
-```
 * Next, check your nginx file:
-* `sudo vim /etc/nginx/sites-available/PROJECTNAME`
-* Check IP_ADDRESS, REPONAME, and PROJECTNAME:
+  * `sudo vim /etc/nginx/sites-available/PROJECTNAME`
+  * Check IP_ADDRESS, REPONAME, and PROJECTNAME:
 ```bash
 server {
     listen 80;

--- a/readme.md
+++ b/readme.md
@@ -244,7 +244,7 @@ Add the following (this will allow you to serve static content):
 STATIC_ROOT = os.path.join(BASE_DIR, "static/")
 # Also enter the line below, repalcing {{yourEC2.public.ip}}
 # with your server's public IP address (leave the quotation marks)
-ALLOWED_HOSTS = ['{{yourEC2.public.ip}}']
+ALLOWED_HOSTS = ['{{yourEC2.public.ip}}','YOURSUBDOMAIN.DOMAIN.COM']
 ```
 Once you are finished making these additions, tell the vim program to exit insert mode by pressing the escape key and then type `:wq` to save your changes and quit vim.
 
@@ -329,6 +329,27 @@ ubuntu@54.162.31.253:~$ sudo systemctl enable gunicorn
 ```
 
 *Note:* if any additional changes are made to the gunicorn.service the previous three commands will need to be run in order to sync things up and restart our service.
+
+*Note 2:* If you're running Ubuntu 14.04, systemctl is not available. Follow the commands listed below. Otherwise, move on.
+
+Enter this command:
+```sudo nano /etc/init/gunicorn.conf```
+Paste in gunicorn.conf: 
+```bash
+description "Gunicorn application server handling PROJECT"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+setuid ubuntu
+setgid www-data
+chdir /home/ubuntu/REPONAME
+
+exec venv/bin/gunicorn --workers 3 --bind unix:/home/ubuntu/REPONAME/PROJECT.sock PROJECT.wsgi:application
+```
+Now, you can run `sudo service gunicorn start`. If you make changes, you can run `sudo service gunicorn restart`
+
 
 
 ## Step 8: Nginx

--- a/readme.md
+++ b/readme.md
@@ -257,10 +257,10 @@ Run `cd ..` to get back to the folder that holds `manage.py`. Make sure your vir
 ```bash
 (venv) ubuntu@54.162.31.253:~myRepoName$ python manage.py collectstatic #say yes
 ```
-## Step 7: Gunicorn
+## Step 7: Gunicorn (Ubuntu 16.04)
 
 
-**WARNING: If you're running Ubuntu 14.04, follow the commands listed in _Note 2 at the end of Step 7_. If you're running Ubuntu 16.04, continue following instructions. **
+**WARNING: If you're running Ubuntu 14.04, systemctl is not available. Skip to Step 7a. If you're running Ubuntu 16.04, continue following instructions for Step 7.**
 
 
 You may remember that Gunicorn is our process manager. Let's test Gunicorn by directing it to our Django project's wsgi.py file, which is the entry point to our application.
@@ -334,18 +334,39 @@ ubuntu@54.162.31.253:~$ sudo systemctl enable gunicorn
 
 *Note:* if any additional changes are made to the gunicorn.service the previous three commands will need to be run in order to sync things up and restart our service.
 
-**Note 2: If you're running _Ubuntu 14.04_, systemctl is not available. Follow the commands listed below. Otherwise, skip to _Step 8_.**
-
-Enter this command:
+## Step 7a: Gunicorn (Ubuntu 14.04)
 
 
+**WARNING: If you're running Ubuntu 14.04, systemctl is not available. Follow the commands listed below. Otherwise, skip to Step 8.**
 
+
+You may remember that Gunicorn is our process manager. Let's test Gunicorn by directing it to our Django project's wsgi.py file, which is the entry point to our application.
+
+Make sure you are in your repo folder and then enter the following:
+
+```
+(venv) ubuntu@54.162.31.253:~myRepoName$ gunicorn --bind 0.0.0.0:8000 {{projectName}}.wsgi:application
+```
+
+If your Gunicorn process ran correctly, you will see something like the following printed to the terminal:
+
+```
+[2016-12-27 05:45:56 +0000] [8695] [INFO] Starting gunicorn 19.6.0
+[2016-12-27 05:45:56 +0000] [8695] [INFO] Listening at: http://0.0.0.0:8000 (8695)
+[2016-12-27 05:45:56 +0000] [8695] [INFO] Using worker: sync
+[2016-12-27 05:45:56 +0000] [8700] [INFO] Booting worker with pid: 8700
+```
+
+To exit the process `ctrl-c`
+
+Now, `deactivate` your virtual environment.
+
+Next, let's set up Gunicorn to run as a service. The primary advantage of turning Gunicorn into a service is that Gunicorn will start with the server after being rebooted and once configured will just work. We will accomplish this in a gunicorn.conf file.
+
+Create the guicorn.conf in your command line:
 ```sudo nano /etc/init/gunicorn.conf```
 
-
-Paste in gunicorn.conf: 
-
-
+Paste this into your gunicorn.conf (replace PROJECT and REPONAME): 
 ```bash
 description "Gunicorn application server handling PROJECT"
 
@@ -359,6 +380,8 @@ chdir /home/ubuntu/REPONAME
 
 exec venv/bin/gunicorn --workers 3 --bind unix:/home/ubuntu/REPONAME/PROJECT.sock PROJECT.wsgi:application
 ```
+
+
 Now, you can run `sudo service gunicorn start`. If you make changes, you can run `sudo service gunicorn restart`
 
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ We're going to use github to create a copy of our project in deployment.
 In the first 2 steps, we will be navigating around on your local machine.  If you are using unix(mac), or linux, these commands are for you.  If you are on Windows, you will want to use git bash in order for these commands to run properly.
 
 ## Overview of Steps
-* **[Step 0](#step-0):** Replace your manage.py file to set PORT
+* **[Step 0](https://github.com/alex-wap/DjangoDeployment#step-0-replace-your-managepy-file-do-not-forget-to-replace-projectname-and-port-with-your-project-name-and-port-number):** Replace your manage.py file to set PORT
 * **Step 1:** Save your installed pip modules in a text file
 * **Step 2:** Push your project to a GitHub repo
 * **Step 3:** Create an EC2 server instance

--- a/readme.md
+++ b/readme.md
@@ -259,6 +259,10 @@ Run `cd ..` to get back to the folder that holds `manage.py`. Make sure your vir
 ```
 ## Step 7: Gunicorn
 
+
+**WARNING: If you're running Ubuntu 14.04, follow the commands listed in *Note 2 at the end of Step 7*. If you're running Ubuntu 16.04, continue following instructions. **
+
+
 You may remember that Gunicorn is our process manager. Let's test Gunicorn by directing it to our Django project's wsgi.py file, which is the entry point to our application.
 
 Make sure you are in your repo folder and then enter the following:
@@ -330,7 +334,7 @@ ubuntu@54.162.31.253:~$ sudo systemctl enable gunicorn
 
 *Note:* if any additional changes are made to the gunicorn.service the previous three commands will need to be run in order to sync things up and restart our service.
 
-**Note 2: If you're running Ubuntu 14.04, systemctl is not available. Follow the commands listed below. Otherwise, move on.**
+**Note 2: If you're running *Ubuntu 14.04, systemctl is not available. Follow the commands listed below. Otherwise, skip to *Step 8*.**
 
 Enter this command:
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ We're going to use github to create a copy of our project in deployment.
 In the first 2 steps, we will be navigating around on your local machine.  If you are using unix(mac), or linux, these commands are for you.  If you are on Windows, you will want to use git bash in order for these commands to run properly.
 
 ## Overview of Steps
-* **[Step 0](https://github.com/alex-wap/DjangoDeployment#step-0-replace-your-managepy-file-do-not-forget-to-replace-projectname-and-port-with-your-project-name-and-port-number):** Replace your manage.py file to set PORT
+* **[Step 0](http://github.com/alex-wap/DjangoDeployment#step-0-replace-your-managepy-file-do-not-forget-to-replace-projectname-and-port-with-your-project-name-and-port-number):** Replace your manage.py file to set PORT
 * **Step 1:** Save your installed pip modules in a text file
 * **Step 2:** Push your project to a GitHub repo
 * **Step 3:** Create an EC2 server instance

--- a/readme.md
+++ b/readme.md
@@ -337,7 +337,7 @@ ubuntu@54.162.31.253:~$ sudo systemctl enable gunicorn
 ## Step 7a: Gunicorn (Ubuntu 14.04)
 
 
-**WARNING: If you're running Ubuntu 14.04, systemctl is not available. Follow the commands listed below. Otherwise, skip to Step 8.**
+**WARNING: If you're running Ubuntu 16.04, you will use systemctl. Follow the commands listed in Step 7.**
 
 
 You may remember that Gunicorn is our process manager. Let's test Gunicorn by directing it to our Django project's wsgi.py file, which is the entry point to our application.

--- a/readme.md
+++ b/readme.md
@@ -337,7 +337,7 @@ ubuntu@54.162.31.253:~$ sudo systemctl enable gunicorn
 ## Step 7a: Gunicorn (Ubuntu 14.04)
 
 
-**WARNING: If you're running Ubuntu 16.04, you will use systemctl. Follow the commands listed in Step 7.**
+**WARNING: If you're running Ubuntu 16.04, you will use systemctl. Follow the commands listed in Step 7. If you're running Ubuntu 14.04, continue following instructions for Step 7a.**
 
 
 You may remember that Gunicorn is our process manager. Let's test Gunicorn by directing it to our Django project's wsgi.py file, which is the entry point to our application.


### PR DESCRIPTION
- now there's an overview of steps.
- added links in overview to jump to each section
- added step 0, which lets you set the port for multiple django projects on a single instance
- added support for ubuntu 14.04 (which cannot use systemctl)
- added more info for common errors, such as internal server error 500 and bad gateway 502